### PR TITLE
Updates for the GA release of Cloud Run for Anthos

### DIFF
--- a/identity-platform/gke/README.md
+++ b/identity-platform/gke/README.md
@@ -1,9 +1,9 @@
-# Authenticating Cloud Run on GKE end users using Istio and Identity Platform
+# Authenticating end users of Cloud Run for Anthos services using Istio and Identity Platform
 
 This directory contains the sample code used in the tutorial
-[Authenticating Cloud Run on GKE end users using Istio and Identity Platform](https://cloud.google.com/solutions/authenticating-cloud-run-on-gke-end-users-using-istio-and-identity-platform).
+[Authenticating end users of Cloud Run for Anthos services using Istio and Identity Platform](https://cloud.google.com/solutions/authenticating-cloud-run-on-gke-end-users-using-istio-and-identity-platform).
 The tutorial demonstrates how to authenticate end users to applications
-deployed to [Cloud Run on GKE](https://cloud.google.com/run/) using
+deployed to [Cloud Run for Anthos](https://cloud.google.com/run/) using
 [Istio authentication policies](https://istio.io/docs/concepts/security/#authentication-policies)
 and [Identity Platform](https://cloud.google.com/identity-platform/).
 
@@ -21,14 +21,13 @@ Follow the steps below to create the GCP resources used in the tutorial.
         CLUSTER=cloud-run-gke-auth-tutorial
         ZONE=us-central1-c
 
-3. Create a GKE cluster with the Cloud Run and Istio add-ons:
+3. Create a GKE cluster with the Cloud Run add-on:
 
         gcloud beta container clusters create $CLUSTER \
-            --addons HttpLoadBalancing,Istio,CloudRun \
-            --cluster-version 1.13 \
+            --addons HorizontalPodAutoscaling,HttpLoadBalancing,CloudRun \
             --enable-ip-alias \
             --enable-stackdriver-kubernetes \
-            --machine-type n1-standard-4
+            --machine-type n1-standard-2 \
             --zone $ZONE
 
 4. Go to the
@@ -73,7 +72,7 @@ Follow the steps below to create the GCP resources used in the tutorial.
 11. Deploy the frontend container image to Cloud Run on GKE as a service in
     the `public` namespace:
 
-        gcloud beta run deploy frontend \
+        gcloud run deploy frontend \
             --namespace public \
             --image gcr.io/$GOOGLE_CLOUD_PROJECT/cloud-run-gke-auth-frontend \
             --platform gke \
@@ -83,7 +82,7 @@ Follow the steps below to create the GCP resources used in the tutorial.
 12. Deploy the backend container image to Cloud Run on GKE as a service in
     the `api` namespace:
 
-        gcloud beta run deploy backend \
+        gcloud run deploy backend \
             --namespace api \
             --image gcr.io/$GOOGLE_CLOUD_PROJECT/cloud-run-gke-auth-backend \
             --platform gke \
@@ -91,13 +90,13 @@ Follow the steps below to create the GCP resources used in the tutorial.
             --cluster-location $ZONE
 
 13. Create an
-    [Istio virtual service](https://archive.istio.io/v1.1/docs/reference/config/networking/v1alpha3/virtual-service/)
+    [Istio virtual service](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/)
     that routes requests by URI path:
 
         kubectl apply -f istio/virtualservice.yaml
 
 14. Create an
-    [Istio authentication policy](https://archive.istio.io/v1.1/docs/reference/config/istio.authentication.v1alpha1/):
+    [Istio authentication policy](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/):
 
         envsubst < istio/authenticationpolicy.template.yaml | \
             kubectl apply -f -

--- a/identity-platform/gke/backend/Dockerfile
+++ b/identity-platform/gke/backend/Dockerfile
@@ -14,7 +14,7 @@
 
 # https://docs.docker.com/engine/reference/builder/
 
-FROM python:3.7-alpine
+FROM python:3.8
 ENV PORT=8080
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/identity-platform/gke/backend/requirements.txt
+++ b/identity-platform/gke/backend/requirements.txt
@@ -14,5 +14,5 @@
 
 # https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
 
-Flask==1.0.3
-gunicorn==19.9.0
+Flask==1.1.1
+gunicorn==20.0.0

--- a/identity-platform/gke/frontend/Dockerfile
+++ b/identity-platform/gke/frontend/Dockerfile
@@ -14,7 +14,7 @@
 
 # https://docs.docker.com/engine/reference/builder/
 
-FROM python:3.7-alpine
+FROM python:3.8
 ENV PORT=8080
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/identity-platform/gke/frontend/index.html
+++ b/identity-platform/gke/frontend/index.html
@@ -18,10 +18,10 @@ limitations under the License.
   <head>
     <meta charset="utf-8">
     <title>Identity Platform Authentication Demo</title>
-    <script src="https://www.gstatic.com/firebasejs/6.2.2/firebase-app.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/6.2.2/firebase-auth.js"></script>
-    <script src="https://cdn.firebase.com/libs/firebaseui/4.0.0/firebaseui.js"></script>
-    <link type="text/css" rel="stylesheet" href="https://cdn.firebase.com/libs/firebaseui/4.0.0/firebaseui.css" />
+    <script src="https://www.gstatic.com/firebasejs/7.3.0/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/7.3.0/firebase-auth.js"></script>
+    <script src="https://cdn.firebase.com/libs/firebaseui/4.2.0/firebaseui.js"></script>
+    <link type="text/css" rel="stylesheet" href="https://cdn.firebase.com/libs/firebaseui/4.2.0/firebaseui.css" />
   </head>
   <body style="text-align: center">
     <h1>Identity Platform Authentication Demo</h1>

--- a/identity-platform/gke/frontend/requirements.txt
+++ b/identity-platform/gke/frontend/requirements.txt
@@ -14,5 +14,5 @@
 
 # https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
 
-Flask==1.0.3
-gunicorn==19.9.0
+Flask==1.1.1
+gunicorn==20.0.0

--- a/identity-platform/gke/istio/authenticationpolicy.template.yaml
+++ b/identity-platform/gke/istio/authenticationpolicy.template.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# https://archive.istio.io/v1.1/docs/reference/config/istio.authentication.v1alpha1/
+# https://istio.io/docs/reference/config/istio.authentication.v1alpha1/
 # https://firebase.google.com/docs/auth/admin/verify-id-tokens#verify_id_tokens_using_a_third-party_jwt_library
 
 # [START run_gke_auth_identityplatform_authenticationpolicy]
@@ -20,10 +20,10 @@ apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
   name: api-origin-auth
-  namespace: istio-system
+  namespace: gke-system
 spec:
   targets:
-  - name: istio-ingressgateway
+  - name: istio-ingress
     ports:
     - number: 80
     - number: 443

--- a/identity-platform/gke/istio/virtualservice.yaml
+++ b/identity-platform/gke/istio/virtualservice.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# https://archive.istio.io/v1.1/docs/reference/config/networking/v1alpha3/virtual-service/
+# https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/
 
 # [START run_gke_auth_identityplatform_virtualservice]
 apiVersion: networking.istio.io/v1alpha3
@@ -21,24 +21,24 @@ metadata:
   name: cloud-run-gke-auth
 spec:
   gateways:
-  - knative-ingress-gateway.knative-serving.svc.cluster.local
+  - gke-system-gateway.knative-serving.svc.cluster.local
   hosts:
-  - '*'
+  - "*"
   http:
   - match:
     - uri:
-        prefix: /api/
+        prefix: "/api/"
     rewrite:
       authority: backend.api.svc.cluster.local
     route:
     - destination:
-        host: istio-ingressgateway.istio-system.svc.cluster.local
+        host: cluster-local-gateway.gke-system.svc.cluster.local
   - match:
     - uri:
-        prefix: /
+        prefix: "/"
     rewrite:
       authority: frontend.public.svc.cluster.local
     route:
     - destination:
-        host: istio-ingressgateway.istio-system.svc.cluster.local
+        host: cluster-local-gateway.gke-system.svc.cluster.local
 # [END run_gke_auth_identityplatform_virtualservice]


### PR DESCRIPTION
- Istio ingress moved from istio-system/istio-ingressgateway to
  gke-system/istio-ingress
- beta prefix no longer required for Cloud Run deployment
- Upgrade to Python 3.8
- Upgrade Flask and Gunicorn
- Upgrade Firebase and FirebaseUI client libraries