### PR TITLE
helloworld-shell: initial commit

### DIFF
--- a/helloworld-shell/Dockerfile
+++ b/helloworld-shell/Dockerfile
@@ -34,8 +34,6 @@ COPY invoke.go ./
 # Build the binary.
 RUN go build -mod=readonly -v -o server
 
-# Whitespace 
-
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/helloworld-shell/Dockerfile
+++ b/helloworld-shell/Dockerfile
@@ -34,6 +34,8 @@ COPY invoke.go ./
 # Build the binary.
 RUN go build -mod=readonly -v -o server
 
+
+
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/helloworld-shell/Dockerfile
+++ b/helloworld-shell/Dockerfile
@@ -34,8 +34,6 @@ COPY invoke.go ./
 # Build the binary.
 RUN go build -mod=readonly -v -o server
 
-
-
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/helloworld-shell/Dockerfile
+++ b/helloworld-shell/Dockerfile
@@ -34,6 +34,8 @@ COPY invoke.go ./
 # Build the binary.
 RUN go build -mod=readonly -v -o server
 
+# Whitespace 
+
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/helloworld-shell/Dockerfile
+++ b/helloworld-shell/Dockerfile
@@ -1,0 +1,52 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START run_helloworld_dockerfile]
+
+# Use the offical golang image to create a binary.
+# This is based on Debian and sets the GOPATH to /go.
+# https://hub.docker.com/_/golang
+FROM golang:1.14-buster as builder
+
+# Create and change to the app directory.
+WORKDIR /app
+
+# Retrieve application dependencies.
+# This allows the container build to reuse cached dependencies.
+# Expecting to copy go.mod and if present go.sum.
+COPY go.* ./
+RUN go mod download
+
+# Copy local code to the container image.
+COPY invoke.go ./
+
+# Build the binary.
+RUN go build -mod=readonly -v -o server
+
+# Use the official Debian slim image for a lean production container.
+# https://hub.docker.com/_/debian
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM debian:buster-slim
+RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy the binary to the production image from the builder stage.
+COPY --from=builder /app/server /app/server
+COPY script.sh ./
+
+# Run the web service on container startup.
+CMD ["/app/server"]
+
+# [END run_helloworld_dockerfile]

--- a/helloworld-shell/go.mod
+++ b/helloworld-shell/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleCloudPlatform/cloud-run-samples/helloworld-shell
+
+go 1.14

--- a/helloworld-shell/invoke.go
+++ b/helloworld-shell/invoke.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START run_helloworld_server]
+
+// Sample helloworld-shell is a Cloud Run shell-script-as-a-service.
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	http.HandleFunc("/", scriptHandler)
+
+	// Determine port for HTTP service.
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+		log.Printf("Defaulting to port %s", port)
+	}
+
+	// Start HTTP server.
+	log.Printf("Listening on port %s", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func scriptHandler(w http.ResponseWriter, r *http.Request) {
+	cmd := exec.CommandContext(r.Context(), "/bin/sh", "script.sh")
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		w.WriteHeader(500)
+	}
+	w.Write(out)
+}
+
+// [END run_helloworld_server]

--- a/helloworld-shell/script.sh
+++ b/helloworld-shell/script.sh
@@ -1,0 +1,21 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START run_helloworld_shell]
+
+#!/bin/bash
+set -e
+echo "Hello ${NAME:-World}!"
+
+# [END run_helloworld_shell]

--- a/helloworld-shell/tests.cloudbuild.yaml
+++ b/helloworld-shell/tests.cloudbuild.yaml
@@ -21,6 +21,7 @@ steps:
      --no-allow-unauthenticated \
      --region ${_SERVICE_REGION} \
      --platform managed
+
 - id: 'Get Cloud Run URL'
   name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
   entrypoint: '/bin/bash'
@@ -33,6 +34,7 @@ steps:
     }
     echo $(get_url) > _service_url
     echo "Cloud Run URL for ${_SERVICE}-$(cat _short_id) is $(cat _service_url)"
+
 - id: 'Integration Tests'
   # TODO: Update the following image name, entrypoint, and args to fit your testing needs
   name: 'alpine:3'
@@ -42,6 +44,7 @@ steps:
   - '-c'
   - |
     echo "Add integration tests!"
+
 - id: 'Teardown'
   name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
   entrypoint: '/bin/bash'
@@ -53,6 +56,7 @@ steps:
     gcloud --quiet run services delete ${_SERVICE}-$(cat _short_id) --region ${_SERVICE_REGION} --platform managed
     set +x
     echo "View build details in the console: https://console.cloud.google.com/cloud-build/builds/${BUILD_ID}"
+
 # Uncomment if skipping teardown to associate build with container image.
 # images:
 # - 'gcr.io/${PROJECT_ID}/${_SERVICE}:${SHORT_SHA}'

--- a/helloworld-shell/tests.cloudbuild.yaml
+++ b/helloworld-shell/tests.cloudbuild.yaml
@@ -1,0 +1,65 @@
+steps:
+
+- id: 'Build Container Image'
+  name: 'gcr.io/cloud-builders/docker:latest'
+  dir: '${_SAMPLE_DIR}'
+  args: ['build', '-t', 'gcr.io/${PROJECT_ID}/${_SERVICE}:${SHORT_SHA}', '.'] # Tag docker image with git commit sha
+
+- id: 'Push Container Image'
+  name: 'gcr.io/cloud-builders/docker:latest'
+  args: ['push', 'gcr.io/${PROJECT_ID}/${_SERVICE}:${SHORT_SHA}']
+
+- id: 'Deploy to Cloud Run'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: /bin/bash
+  args:
+  - '-c'
+  - | # Cloud Run Service name must be less than 63 characters
+    cat /dev/urandom | LC_CTYPE=C tr -dc 'a-z0-9' | head -c 15 > _short_id # Generate a random 15 character alphanumeric string (lowercase only)
+    gcloud run deploy ${_SERVICE}-$(cat _short_id) \
+     --image gcr.io/${PROJECT_ID}/${_SERVICE}:${SHORT_SHA} \
+     --no-allow-unauthenticated \
+     --region ${_SERVICE_REGION} \
+     --platform managed
+- id: 'Get Cloud Run URL'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - |
+    get_url() {
+        gcloud run services describe ${_SERVICE}-$(cat _short_id) --format 'value(status.url)' \
+          --platform managed --region ${_SERVICE_REGION}
+    }
+    echo $(get_url) > _service_url
+    echo "Cloud Run URL for ${_SERVICE}-$(cat _short_id) is $(cat _service_url)"
+- id: 'Integration Tests'
+  # TODO: Update the following image name, entrypoint, and args to fit your testing needs
+  name: 'alpine:3'
+  entrypoint: '/bin/sh'
+  dir: '${_SAMPLE_DIR}'
+  args:
+  - '-c'
+  - |
+    echo "Add integration tests!"
+- id: 'Teardown'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - |
+    set -x
+    gcloud --quiet container images delete gcr.io/${PROJECT_ID}/${_SERVICE}:${SHORT_SHA}
+    gcloud --quiet run services delete ${_SERVICE}-$(cat _short_id) --region ${_SERVICE_REGION} --platform managed
+    set +x
+    echo "View build details in the console: https://console.cloud.google.com/cloud-build/builds/${BUILD_ID}"
+# Uncomment if skipping teardown to associate build with container image.
+# images:
+# - 'gcr.io/${PROJECT_ID}/${_SERVICE}:${SHORT_SHA}'
+
+# TODO: Update these User-defined substitutions
+substitutions:
+  _SERVICE: helloworld-shell
+  _SAMPLE_DIR: helloworld-shell
+  _SERVICE_REGION: us-central1
+  _CLOUDSDK_VERSION: latest


### PR DESCRIPTION
`helloworld-shell` demonstrates how to run arbitrary shell scripts as a Cloud Run service. It uses go to build an HTTP server, and while the go code is shown in the quickstart is really a means to showing the "pattern". More detailed, language-by-language shell execution is showcased in https://cloud.google.com/run/docs/tutorials/system-packages.

This PR is going to be incrementally built in tandem with this repositories CI implementation, currently lacks README and tests but these are expected by merge.