### PR TITLE
Fix keys used in authorization policy rules

### DIFF
--- a/istio-authorization/authorizationpolicy-invoker.tmpl.yaml
+++ b/istio-authorization/authorizationpolicy-invoker.tmpl.yaml
@@ -22,13 +22,13 @@ spec:
   action: ALLOW
   rules:
   - when:
-    - key: request.auth.audiences
+    - key: request.auth.claims[aud]
       values:
       - http://example.com
     - key: request.auth.claims[iss]
       values:
       - https://accounts.google.com
-    - key: request.auth.principal
+    - key: request.auth.claims[email]
       values:
       - $SERVICE_ACCOUNT_EMAIL
 # [END run_gke_invoker_authorizationpolicy_invoker]


### PR DESCRIPTION
The value of request.auth.principal is the unique user ID in the `sub`
claim, so we need to use the `email` claim instead.