### PR TITLE
Add workload selector to authorization policies

### DIFF
--- a/istio-authorization/authorizationpolicy-invoker.tmpl.yaml
+++ b/istio-authorization/authorizationpolicy-invoker.tmpl.yaml
@@ -31,4 +31,6 @@ spec:
     - key: request.auth.claims[email]
       values:
       - $SERVICE_ACCOUNT_EMAIL
+  selector:
+    matchLabels: {}
 # [END run_gke_invoker_authorizationpolicy_invoker]

--- a/istio-authorization/authorizationpolicy-knative-serving.yaml
+++ b/istio-authorization/authorizationpolicy-knative-serving.yaml
@@ -34,4 +34,6 @@ spec:
         - /metrics
         - /probe
         - /_internal/knative/*
+  selector:
+    matchLabels: {}
 # [END run_gke_invoker_authorizationpolicy_knative_serving]


### PR DESCRIPTION
An empty workload selector is required for the authorization policies to
apply to all workloads in the namespace.

Without the workload selector, requests to a second kservice in the same
namespace would hang.