### PR TITLE
testing: add support for minting identity tokens

### DIFF
--- a/helloworld-shell/nightly.trigger-config.yaml
+++ b/helloworld-shell/nightly.trigger-config.yaml
@@ -8,3 +8,6 @@ github:
 includedFiles:
 - helloworld-shell/**
 filename: helloworld-shell/tests.cloudbuild.yaml
+substitutions:
+  _RUNNER_IDENTITY: test-runner-identity@cloud-run-samples-test.iam.gserviceaccount.com
+  _SECRET_NAME: locksmith-secret

--- a/helloworld-shell/pr.trigger-config.yaml
+++ b/helloworld-shell/pr.trigger-config.yaml
@@ -1,13 +1,15 @@
-name: helloworld-pr
+createTime: '2020-05-29T20:27:39.708433796Z'
 description: pull-request
+filename: helloworld-shell/tests.cloudbuild.yaml
 github:
   name: cloud-run-samples
   owner: GoogleCloudPlatform
   pullRequest:
     branch: ^master$
+id: c6ba6276-de94-4471-9ce0-a16b4bd5ff8e
 includedFiles:
-- helloworld-shell/**
-filename: helloworld-shell/tests.cloudbuild.yaml
+- helloworld-shell/*
+name: helloworld-pr
 substitutions:
   _RUNNER_IDENTITY: test-runner-identity@cloud-run-samples-test.iam.gserviceaccount.com
   _SECRET_NAME: locksmith-secret

--- a/helloworld-shell/pr.trigger-config.yaml
+++ b/helloworld-shell/pr.trigger-config.yaml
@@ -8,3 +8,6 @@ github:
 includedFiles:
 - helloworld-shell/**
 filename: helloworld-shell/tests.cloudbuild.yaml
+substitutions:
+  _RUNNER_IDENTITY: test-runner-identity@cloud-run-samples-test.iam.gserviceaccount.com
+  _SECRET_NAME: locksmith-secret

--- a/helloworld-shell/tests.cloudbuild.yaml
+++ b/helloworld-shell/tests.cloudbuild.yaml
@@ -17,10 +17,9 @@ steps:
   - | # Cloud Run Service name must be less than 63 characters
     cat /dev/urandom | LC_CTYPE=C tr -dc 'a-z0-9' | head -c 15 > _short_id # Generate a random 15 character alphanumeric string (lowercase only)
     gcloud run deploy ${_SERVICE}-$(cat _short_id) \
-     --image gcr.io/${PROJECT_ID}/${_SERVICE}:${SHORT_SHA} \
-     --no-allow-unauthenticated \
-     --region ${_SERVICE_REGION} \
-     --platform managed
+      --image gcr.io/${PROJECT_ID}/${_SERVICE}:${SHORT_SHA} \
+      --no-allow-unauthenticated \
+      --platform managed
 
 - id: 'Get Cloud Run URL'
   name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
@@ -28,22 +27,29 @@ steps:
   args:
   - '-c'
   - |
-    get_url() {
-        gcloud run services describe ${_SERVICE}-$(cat _short_id) --format 'value(status.url)' \
-          --platform managed --region ${_SERVICE_REGION}
-    }
+    set -e
+    . /workspace/testing/cloudbuild-templates/common.sh
     echo $(get_url) > _service_url
     echo "Cloud Run URL for ${_SERVICE}-$(cat _short_id) is $(cat _service_url)"
+    echo $(get_idtoken) > _id_token
+  env:
+    # Make substitutions available in shell script.
+    - "_SECRET_NAME=${_SECRET_NAME}"
+    - "_RUNNER_IDENTITY=${_RUNNER_IDENTITY}"
+    - "_SERVICE=${_SERVICE}"
+
+# If env is set VAR=VAL without the preceding hyphen in `env:` it concatenates the values.
+# This does not seem like expected behavior. For example:
 
 - id: 'Integration Tests'
   # TODO: Update the following image name, entrypoint, and args to fit your testing needs
-  name: 'alpine:3'
+  name: 'gcr.io/cloud-builders/curl'
   entrypoint: '/bin/sh'
-  dir: '${_SAMPLE_DIR}'
   args:
   - '-c'
   - |
-    echo "Add integration tests!"
+    set -e
+    curl -si -H "Authorization: Bearer $(cat _id_token)" "$(cat _service_url)"
 
 - id: 'Teardown'
   name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
@@ -60,6 +66,11 @@ steps:
 # Uncomment if skipping teardown to associate build with container image.
 # images:
 # - 'gcr.io/${PROJECT_ID}/${_SERVICE}:${SHORT_SHA}'
+
+options:
+  env:
+    - "CLOUDSDK_RUN_REGION=${_SERVICE_REGION}"
+    - "GOOGLE_CLOUD_PROJECT=${PROJECT_ID}"
 
 # TODO: Update these User-defined substitutions
 substitutions:

--- a/helloworld-shell/tests.cloudbuild.yaml
+++ b/helloworld-shell/tests.cloudbuild.yaml
@@ -48,7 +48,7 @@ steps:
   - '-c'
   - |
     set -e
-    curl -si -H "Authorization: Bearer $(cat _id_token)" "$(cat _service_url)"
+    curl -si --fail --show-error -H "Authorization: Bearer $(cat _id_token)" "$(cat _service_url)"
 
 - id: 'Teardown'
   name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'

--- a/helloworld-shell/tests.cloudbuild.yaml
+++ b/helloworld-shell/tests.cloudbuild.yaml
@@ -38,7 +38,6 @@ steps:
     - "_RUNNER_IDENTITY=${_RUNNER_IDENTITY}"
     - "_SERVICE=${_SERVICE}"
 
-# If env is set VAR=VAL without the preceding hyphen in `env:` it concatenates the values.
 # This does not seem like expected behavior. For example:
 
 - id: 'Integration Tests'

--- a/testing/README.md
+++ b/testing/README.md
@@ -154,15 +154,8 @@ To manually trigger a Cloud Run (fully managed) build via CLI:
 ```sh
 SAMPLE=testing/cloudbuild-templates CLOUDSDK_BUILDS_CONFIG=cloud-run-template.cloudbuild.yaml \
 gcloud builds submit \
-  --substitutions "SHORT_SHA=manual,_SAMPLE_DIR=$SAMPLE,_SECRET_NAME=locksmith-secret,_RUNNER_IDENTITY=test-runner-identity@${TESTING_PROJECT}.iam.gserviceaccount.com"
+  --substitutions "SHORT_SHA=manual,_SAMPLE_DIR=$SAMPLE,_SECRET_NAME=${SECRET_NAME},_RUNNER_IDENTITY=${SERVICE_ACCOUNT}@${TESTING_PROJECT}.iam.gserviceaccount.com"
 ```
-
-export SAMPLE=testing/cloudbuild-templates
-export CLOUDSDK_BUILDS_CONFIG=$SAMPLE/cloud-run-template.cloudbuild.yaml
-gcloud builds submit  \
-  --config "$SAMPLE/cloud-run-template.cloudbuild.yaml" \
-  --substitutions "SHORT_SHA=manual,_SAMPLE_DIR=$SAMPLE,_SECRET_NAME=locksmith-secret,_RUNNER_IDENTITY=test-runner-identity@${TESTING_PROJECT}.iam.gserviceaccount.com,_SERVICE=test" 
-
 
 We run from base directory of the repository for access to the common.sh script.
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -152,9 +152,10 @@ These triggers are created using trigger configuration files.
 To manually trigger a Cloud Run (fully managed) build via CLI:
 
 ```sh
-SAMPLE=testing/cloudbuild-templates CLOUDSDK_BUILDS_CONFIG=cloud-run-template.cloudbuild.yaml \
+$SAMPLE=sample-name
 gcloud builds submit \
-  --substitutions "SHORT_SHA=manual,_SAMPLE_DIR=$SAMPLE,_SECRET_NAME=${SECRET_NAME},_RUNNER_IDENTITY=${SERVICE_ACCOUNT}@${TESTING_PROJECT}.iam.gserviceaccount.com"
+  --config "$SAMPLE/tests.cloudbuild.yaml" \
+  --substitutions "SHORT_SHA=manual,_SAMPLE_DIR=${SAMPLE},_SECRET_NAME=${SECRET_NAME},_RUNNER_IDENTITY=${SERVICE_ACCOUNT}@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
 ```
 
 We run from base directory of the repository for access to the common.sh script.

--- a/testing/README.md
+++ b/testing/README.md
@@ -6,41 +6,44 @@ A Google Cloud Project is required in order to run the tests in the Cloud Run Sa
 * Cloud Build
 * Pub/Sub
 * Container Registry
+* Secret Manager
 
 ## Test Project Setup
 
-The [test-project-setup.sh](./test-project-setup.sh) script will set up a project with the appropriate permissions to run the tests.  To run the script you will need to set the following environment variables locally:
+The [test-project-setup.sh](./test-project-setup.sh) script will set up a project with the appropriate permissions to run the tests. To run the script you will need to set the following environment variables locally:
 
 * TEAM_FOLDER [optional]
-  * The numeric ID of the [folder](https://cloud.google.com/sdk/gcloud/reference/projects/create#--folder)
+  * The numeric ID of the [folder][folder]
   * Note: TEAM_FOLDER is optional for the script, but may be required by your organization policy.
 
 * PROJECT_SUFFIX [required]
   * Number to be attached at the end of the PROJECT_ID in order to create a unique project id.
   * Eg: 2
 
+Once basic project setup is in place, Cloud Build must be given access to deploy Cloud Run services (see [Deploying to Cloud Run][access]).
+
+Lastly, the Cloud Build GitHub App needs to be installed and connected to the repository. More info can be found in [Installing the Cloud Build app][app].
+
 ### Billing
 
-The script checks your current active project to obtain the Billing Account, in order to enable the API's.  This account is then linked to the new testing project.
+The script checks your current active project to obtain the Billing Account, in order to enable the API's. This account is then linked to the new testing project.
 
-If your current project does not have a billing account enabled, it will force the program to exit. To select a project to use for your billing account, run ` gcloud config set project {PROJECT_ID}`
+If your current project does not have a billing account enabled, it will force the program to exit. To select a project to use for your billing account, run `gcloud config set project {PROJECT_ID}`.
 
 ## Cloud Build Templates
 
 Cloud Build templates for Cloud Run E2E testing can be found in the
-`cloudbuild-templates/` directory. The `TODO` comment highlights areas that will
-need to be updated:
+`cloudbuild-templates/` directory.
 
 * [User-defined substitutions][sub], such as `_SAMPLE` and `_SERVICE`.
-
-* Evaluate the `--allow-unauthenticated` flag.
 
 * Add integration tests, see examples below:
 
   * Using a shell script:
-    ```
+
+    ```yaml
     - id: 'Integration Tests'
-      name: 'alpine:3'
+      name: 'gcr.io/cloud-builders/curl'
       entrypoint: '/bin/sh'
       dir: $_SAMPLE
       args:
@@ -50,7 +53,8 @@ need to be updated:
     ```
 
   * Language specific testing:
-    ```
+
+    ```yaml
     - id: 'Integration Tests'
       name: 'maven:3-openjdk-11'
       entrypoint: '/bin/bash'
@@ -60,61 +64,116 @@ need to be updated:
       - |
         SERVICE_URL=$(cat _service_url) mvn verify
     ```
+
 **Note:** The build steps for getting the Cloud Run URL and IP are used to
 export environment variables into the test runner.
 
+### Testing private services in Cloud Run (fully managed)
+
+Cloud Run services are deployed privately as a best practice: humans choose to make a service public, not the CI system. Cloud Run is deployed with the `--no-allow-unauthenticated` flag
+to keep it private. To send HTTPS requests to the Cloud Run service, an identity token is required for [an account with the Cloud Run invoker permission](https://cloud.google.com/run/docs/authenticating/service-to-service).
+
+To mint identity tokens on Cloud Build, load an alternate service identity with this permision in the 'Get Cloud Run URL' build step:
+
+```sh
+gcloud secrets versions access latest --secret ${_SECRET_NAME} > _sa_key.json
+account=$(gcloud config get-value account)
+gcloud auth activate-service-account ${_RUNNER_IDENTITY} \
+  --key-file _sa_key.json --project ${PROJECT_ID}
+gcloud auth print-identity-token --audiences "$(cat _service_url)" > _id_token
+gcloud config set account ${account}
+rm _sa_key.json
+```
+
+This secret is populated by a separate key rotation process, such as:
+
+```sh
+export SERVICE_ACCOUNT="test-runner-identity"
+gcloud iam services-accounts keys create "${SERVICE_ACCOUNT}-key.json" \
+  --iam-account "${SERVICE_ACCOUNT}@${TESTING_PROJECT}.iam.gserviceaccount.com"
+gcloud secrets versions add locksmith-secret --data-file "${SERVICE_ACCOUNT}-key.json"
+rm $SERVICE_ACCOUNT-key.json
+```
+
+Once done, any previous key should be revoked.
+
 ## Cloud Build Triggers
 
-Before trigger creation, you need to enable access for the Cloud Build service account to deploy the service. More information can be found in [Setting up continuous deployment with Cloud Build][access]. The Cloud Build GitHub App also needs to be installed and connected to the repository. More info can be found in [Installing the Cloud Build app][app].
+Each sample with tests requires two Cloud Build triggers:
 
-1. Add a Cloud Build trigger config YAML file:
+* A **Pull Request trigger** which checks incoming changes.
+* A **Nightly trigger** which checks the affects of product changes, environment changes, and flakiness.
 
-  **Pull Request Trigger Config**
+These triggers are created using trigger configuration files.
 
-  ```YAML
-  name: SAMPLE-pr
-  description: pull-request
-  github:
-    name: cloud-run-samples
-    owner: GoogleCloudPlatform
-    pullRequest:
-      branch: ^master$
-  includedFiles:
-  - SAMPLE_DIR/**
-  filename: SAMPLE_DIR/cloudbuild.yaml
-  ```
+1. Create the sample Pull Request trigger config (`pr.trigger-config.yaml`):
 
-  **Nightly Trigger Config**
+   ```yaml
+   name: SAMPLE-pr
+   description: pull-request
+   github:
+     name: cloud-run-samples
+     owner: GoogleCloudPlatform
+     pullRequest:
+       branch: ^master$
+   includedFiles:
+   - SAMPLE_DIR/**
+   filename: SAMPLE_DIR/cloudbuild.yaml
+   ```
 
-  Our nightly testing uses "manual" Cloud Build triggers. The Cloud Build Trigger UI is currently the only way to create manual triggers. A current work around is creating a "Push to branch" event trigger. This can be manually triggered and can be updated via the UI to be a "Manually run" trigger.
+1. Create the sample Nightly trigger config (`nightly.trigger-config.yaml`):
 
-  ```YAML
-  name: SAMPLE-nightly
-  description: nightly
-  github:
-    name: cloud-run-samples
-    owner: GoogleCloudPlatform
-    push: # TODO: Update when manual triggers are supported
-      branch: nightly
-  includedFiles:
-  - SAMPLE_DIR/**
-  filename: SAMPLE_DIR/cloudbuild.yaml
-  ```
+   Our nightly testing uses "manual" Cloud Build triggers. The Cloud Build Trigger UI is currently the only way to create manual triggers. A current work around is creating a "Push to branch" event trigger. This can be manually triggered and can be updated via the UI to be a "Manually run" trigger.
+
+   ```yaml
+   name: SAMPLE-nightly
+   description: nightly
+   github:
+     name: cloud-run-samples
+     owner: GoogleCloudPlatform
+     push: # TODO: Update when manual triggers are supported
+       branch: nightly
+   includedFiles:
+   - SAMPLE_DIR/**
+   filename: SAMPLE_DIR/cloudbuild.yaml
+   ```
 
 1. Create a Cloud Build trigger using a config file:
 
-  ```shell
-  gcloud beta builds triggers create github --trigger-config=path/to/trigger-config.yaml
-  ```
+   ```sh
+   gcloud beta builds triggers create github \
+     --trigger-config=sample/path/pr.trigger-config.yaml
+   gcloud beta builds triggers create github \
+     --trigger-config=sample/path/nightly.trigger-config.yaml
+   ```
 
 ## Manually Start Cloud Builds
 
-To manually trigger a Cloud Build from your CLI:
-```
-cd $SAMPLE
-gcloud builds submit --substitutions '_SAMPLE_DIR=.,SHORT_SHA=manual'
+To manually trigger a Cloud Run (fully managed) build via CLI:
+
+```sh
+SAMPLE=testing/cloudbuild-templates CLOUDSDK_BUILDS_CONFIG=cloud-run-template.cloudbuild.yaml \
+gcloud builds submit \
+  --substitutions "SHORT_SHA=manual,_SAMPLE_DIR=$SAMPLE,_SECRET_NAME=locksmith-secret,_RUNNER_IDENTITY=test-runner-identity@${TESTING_PROJECT}.iam.gserviceaccount.com"
 ```
 
-[access]: https://cloud.google.com/run/docs/continuous-deployment-with-cloud-build#continuous
+export SAMPLE=testing/cloudbuild-templates
+export CLOUDSDK_BUILDS_CONFIG=$SAMPLE/cloud-run-template.cloudbuild.yaml
+gcloud builds submit  \
+  --config "$SAMPLE/cloud-run-template.cloudbuild.yaml" \
+  --substitutions "SHORT_SHA=manual,_SAMPLE_DIR=$SAMPLE,_SECRET_NAME=locksmith-secret,_RUNNER_IDENTITY=test-runner-identity@${TESTING_PROJECT}.iam.gserviceaccount.com,_SERVICE=test" 
+
+
+We run from base directory of the repository for access to the common.sh script.
+
+To manually trigger a Cloud Run for Anthos build via CLI:
+
+```sh
+cd $SAMPLE
+gcloud builds submit --substitutions 'SHORT_SHA=manual,_SAMPLE_DIR=.'
+```
+
+[folder]: https://cloud.google.com/sdk/gcloud/reference/projects/create#--folder
+[access]: https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-cloud-run
 [app]: https://cloud.google.com/cloud-build/docs/automating-builds/create-github-app-triggers#installing_the_cloud_build_app
 [sub]: https://cloud.google.com/cloud-build/docs/configuring-builds/substitute-variable-values#using_user-defined_substitutions

--- a/testing/README.md
+++ b/testing/README.md
@@ -91,7 +91,7 @@ This secret is populated by a separate key rotation process, such as:
 export SERVICE_ACCOUNT="test-runner-identity"
 gcloud iam services-accounts keys create "${SERVICE_ACCOUNT}-key.json" \
   --iam-account "${SERVICE_ACCOUNT}@${TESTING_PROJECT}.iam.gserviceaccount.com"
-gcloud secrets versions add locksmith-secret --data-file "${SERVICE_ACCOUNT}-key.json"
+gcloud secrets versions add ${SECRET_NAME} --data-file "${SERVICE_ACCOUNT}-key.json"
 rm $SERVICE_ACCOUNT-key.json
 ```
 

--- a/testing/cloudbuild-templates/Dockerfile
+++ b/testing/cloudbuild-templates/Dockerfile
@@ -1,3 +1,5 @@
+# This Dockerfile provides a self-contained "Hello, World!" service.
+# It is used to facilitate troubleshooting the Cloud Build templates.
 FROM alpine:3
 
 CMD while :; do nc -l -p $PORT -e sh -c 'echo -e "HTTP/1.1 200 OK\n\n Hello, World!"'; done

--- a/testing/cloudbuild-templates/Dockerfile
+++ b/testing/cloudbuild-templates/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3
+
+CMD while :; do nc -l -p $PORT -e sh -c 'echo -e "HTTP/1.1 200 OK\n\n Hello, World!"'; done

--- a/testing/cloudbuild-templates/cloud-run-anthos-template.cloudbuild.yaml
+++ b/testing/cloudbuild-templates/cloud-run-anthos-template.cloudbuild.yaml
@@ -50,7 +50,7 @@ steps:
 
 - id: 'Integration Tests'
   # TODO: Update the following image name, entrypoint, and args to fit your testing needs
-  name: 'alpine:3'
+  name: 'gcr.io/cloud-builders/curl'
   entrypoint: '/bin/sh'
   dir: '${_SAMPLE_DIR}'
   args:

--- a/testing/cloudbuild-templates/cloud-run-template.cloudbuild.yaml
+++ b/testing/cloudbuild-templates/cloud-run-template.cloudbuild.yaml
@@ -41,8 +41,6 @@ steps:
 # If env is set VAR=VAL without the preceding hyphen in `env:` it concatenates the values.
 # This does not seem like expected behavior. For example:
 
-# locksmith-secret _RUNNER_IDENTITY=test-runner-identity@adamross-svls-kibble.iam.gserviceaccount.com _SERVICE=test
-
 - id: 'Integration Tests'
   # TODO: Update the following image name, entrypoint, and args to fit your testing needs
   name: 'gcr.io/cloud-builders/curl'

--- a/testing/cloudbuild-templates/cloud-run-template.cloudbuild.yaml
+++ b/testing/cloudbuild-templates/cloud-run-template.cloudbuild.yaml
@@ -38,7 +38,6 @@ steps:
     - "_RUNNER_IDENTITY=${_RUNNER_IDENTITY}"
     - "_SERVICE=${_SERVICE}"
 
-# If env is set VAR=VAL without the preceding hyphen in `env:` it concatenates the values.
 # This does not seem like expected behavior. For example:
 
 - id: 'Integration Tests'

--- a/testing/cloudbuild-templates/cloud-run-template.cloudbuild.yaml
+++ b/testing/cloudbuild-templates/cloud-run-template.cloudbuild.yaml
@@ -28,7 +28,7 @@ steps:
   - '-c'
   - |
     set -e
-    . /workspace/testing/cloudbuild-templates/common.sh
+    source /workspace/testing/cloudbuild-templates/common.sh
     echo $(get_url) > _service_url
     echo "Cloud Run URL for ${_SERVICE}-$(cat _short_id) is $(cat _service_url)"
     echo $(get_idtoken) > _id_token
@@ -48,7 +48,7 @@ steps:
   - '-c'
   - |
     set -e
-    curl -si -H "Authorization: Bearer $(cat _id_token)" "$(cat _service_url)"
+    curl -si --fail --show-error -H "Authorization: Bearer $(cat _id_token)" "$(cat _service_url)"
 
 - id: 'Teardown'
   name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'

--- a/testing/cloudbuild-templates/cloud-run-template.cloudbuild.yaml
+++ b/testing/cloudbuild-templates/cloud-run-template.cloudbuild.yaml
@@ -17,10 +17,9 @@ steps:
   - | # Cloud Run Service name must be less than 63 characters
     cat /dev/urandom | LC_CTYPE=C tr -dc 'a-z0-9' | head -c 15 > _short_id # Generate a random 15 character alphanumeric string (lowercase only)
     gcloud run deploy ${_SERVICE}-$(cat _short_id) \
-     --image gcr.io/${PROJECT_ID}/${_SERVICE}:${SHORT_SHA} \
-     --no-allow-unauthenticated \
-     --region ${_SERVICE_REGION} \
-     --platform managed
+      --image gcr.io/${PROJECT_ID}/${_SERVICE}:${SHORT_SHA} \
+      --no-allow-unauthenticated \
+      --platform managed
 
 - id: 'Get Cloud Run URL'
   name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
@@ -28,22 +27,31 @@ steps:
   args:
   - '-c'
   - |
-    get_url() {
-        gcloud run services describe ${_SERVICE}-$(cat _short_id) --format 'value(status.url)' \
-          --platform managed --region ${_SERVICE_REGION}
-    }
+    set -e
+    . /workspace/testing/cloudbuild-templates/common.sh
     echo $(get_url) > _service_url
     echo "Cloud Run URL for ${_SERVICE}-$(cat _short_id) is $(cat _service_url)"
+    echo $(get_idtoken) > _id_token
+  env:
+    # Make substitutions available in shell script.
+    - "_SECRET_NAME=${_SECRET_NAME}"
+    - "_RUNNER_IDENTITY=${_RUNNER_IDENTITY}"
+    - "_SERVICE=${_SERVICE}"
+
+# If env is set VAR=VAL without the preceding hyphen in `env:` it concatenates the values.
+# This does not seem like expected behavior. For example:
+
+# locksmith-secret _RUNNER_IDENTITY=test-runner-identity@adamross-svls-kibble.iam.gserviceaccount.com _SERVICE=test
 
 - id: 'Integration Tests'
   # TODO: Update the following image name, entrypoint, and args to fit your testing needs
-  name: 'alpine:3'
+  name: 'gcr.io/cloud-builders/curl'
   entrypoint: '/bin/sh'
-  dir: '${_SAMPLE_DIR}'
   args:
   - '-c'
   - |
-    echo "Add integration tests!"
+    set -e
+    curl -si -H "Authorization: Bearer $(cat _id_token)" "$(cat _service_url)"
 
 - id: 'Teardown'
   name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
@@ -61,9 +69,14 @@ steps:
 # images:
 # - 'gcr.io/${PROJECT_ID}/${_SERVICE}:${SHORT_SHA}'
 
+options:
+  env:
+    - "CLOUDSDK_RUN_REGION=${_SERVICE_REGION}"
+    - "GOOGLE_CLOUD_PROJECT=${PROJECT_ID}"
+
 # TODO: Update these User-defined substitutions
 substitutions:
-  _SERVICE: SERVICE_NAME
+  _SERVICE: SERVICE_NAME_PREFIX
   _SAMPLE_DIR: SAMPLE_DIRECTORY
   _SERVICE_REGION: us-central1
   _CLOUDSDK_VERSION: latest

--- a/testing/cloudbuild-templates/common.sh
+++ b/testing/cloudbuild-templates/common.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+##
+# common.sh
+# Provides utility functions commonly needed across Cloud Build pipelines.
+#
+# This is expected to be used from cloud-run-template.cloudbuild.yaml and 
+# should be "forked" into an individual sample that does not provide the same
+# environment variables and workspace.
+#
+# It is kept separate for two reasons:
+# 1. Simplicity of cloudbuild.yaml files.
+# 2. Easier evaluation of security implications in changes to get_idtoken().
+#
+# Usage
+# If you do not need to fork this script, directly source it in your YAML file:
+#
+# ```
+# . /testing/cloudbuild-templates/common.sh
+# echo $(get_url) > _service_url
+# ```
+##
+
+# Cloud Run URLs are not deterministic.
+get_url() {
+    gcloud run services describe ${_SERVICE}-$(cat _short_id) \
+        --format 'value(status.url)' \
+        --platform managed
+}
+
+# Cloud Build does not natively mint identity tokens.
+# A separate mechanism pushes a Service Account key into Secret Manager
+# which can be used to create identity tokens.
+get_idtoken() {
+    set -x
+    gcloud secrets versions access latest --secret ${_SECRET_NAME} > _sa_key.json
+    # Capture the current authenticated account.
+    account=$(gcloud config get-value account)
+    gcloud auth activate-service-account ${_RUNNER_IDENTITY} --key-file _sa_key.json --project ${GOOGLE_CLOUD_PROJECT}
+    gcloud auth print-identity-token --audiences "$(cat _service_url)"
+    # Switch to the original account.
+    gcloud config set account ${account}
+    set +x
+    rm _sa_key.json
+} 


### PR DESCRIPTION
This PR is an iteration over the CI implementation of #37.

This mechanism requires a service account key be kept in a secret. The secret name and service account of the key is kept in the build trigger config, though in the future we might parse the the service account name from the key.

TODO: Adding the secret substitution values to the build config, should we add it to the YAML or leave it as a manual instruction? I think I lean toward the YAML but could not find the reference docs on a quick search.

I'm going to place some in-line comments for consideration.