### PR TITLE
fix(hadolint): add --no-cache-dir to pip install

### DIFF
--- a/identity-platform/gke/backend/Dockerfile
+++ b/identity-platform/gke/backend/Dockerfile
@@ -17,7 +17,7 @@
 FROM python:3.8
 ENV PORT=8080
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 WORKDIR /app
-COPY . .
+COPY . ./
 CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app

--- a/identity-platform/gke/frontend/Dockerfile
+++ b/identity-platform/gke/frontend/Dockerfile
@@ -17,7 +17,7 @@
 FROM python:3.8
 ENV PORT=8080
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 WORKDIR /app
-COPY . .
+COPY . ./
 CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app

--- a/vpc-sample/Dockerfile
+++ b/vpc-sample/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR $APP_HOME
 COPY . ./
 
 # Install production dependencies.
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Run the web service on container startup.
 CMD ["functions-framework", "--target=get_hello_world"]


### PR DESCRIPTION
hadolint has what I expect is a new rule that Dockerfiles should use `--no-cache-dir` on pip install. This helps promotes slimmer container images.

This change is currently blocking #65 non urgently (because there are other blockers too). Will raise priority if this becomes the last blocker.