### PR TITLE
Call script with matching shell

### DIFF
--- a/helloworld-shell/invoke.go
+++ b/helloworld-shell/invoke.go
@@ -43,7 +43,7 @@ func main() {
 }
 
 func scriptHandler(w http.ResponseWriter, r *http.Request) {
-	cmd := exec.CommandContext(r.Context(), "/bin/sh", "script.sh")
+	cmd := exec.CommandContext(r.Context(), "/bin/bash", "script.sh")
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
The shebang in `script.sh` specifies `bash`, but `invoke.go` calls it through `sh` instead. This commit reconciles the two values by calling the script with the shell it actually wants.