### PR TITLE
feat: add retry to get_idtoken()

### DIFF
--- a/testing/cloudbuild-templates/common.sh
+++ b/testing/cloudbuild-templates/common.sh
@@ -51,7 +51,14 @@ get_idtoken() {
     # Capture the current authenticated account.
     account=$(gcloud config get-value account)
     gcloud auth activate-service-account ${_RUNNER_IDENTITY} --key-file _sa_key.json --project ${GOOGLE_CLOUD_PROJECT}
-    gcloud auth print-identity-token --audiences "$(cat _service_url)"
+    retries=3
+    while ! gcloud auth print-identity-token --audiences "$(cat _service_url)"
+    do
+      if [ $retries -eq 1 ]; then 
+        break
+      fi
+      let retries--;
+    done
     # Switch to the original account.
     gcloud config set account ${account}
     set +x

--- a/testing/cloudbuild-templates/common.sh
+++ b/testing/cloudbuild-templates/common.sh
@@ -58,6 +58,7 @@ get_idtoken() {
         break
       fi
       let retries--;
+      sleep 3
     done
     # Switch to the original account.
     gcloud config set account ${account}


### PR DESCRIPTION
This PR will add a retry (count of 3) to the `common.sh` testing file. This will reduce test failures due to intermittent failures to retrieve  an identity token (see #204)